### PR TITLE
Add prompt export/import

### DIFF
--- a/web/src/__tests__/prompts.import-export.servertest.ts
+++ b/web/src/__tests__/prompts.import-export.servertest.ts
@@ -1,0 +1,42 @@
+/** @jest-environment node */
+
+import { makeAPICall, pruneDatabase } from "@/src/__tests__/test-utils";
+import { PromptSchema } from "@/src/features/prompts/server/utils/validation";
+
+const baseURI = "/api/public/v2/prompts";
+
+describe("prompt export/import", () => {
+  beforeAll(pruneDatabase);
+  afterAll(pruneDatabase);
+
+  it("should export prompts and import them", async () => {
+    await makeAPICall("POST", baseURI, {
+      name: "prompt-export-1",
+      prompt: "hello",
+      labels: ["production"],
+    });
+    await makeAPICall("POST", baseURI, {
+      name: "prompt-export-2",
+      prompt: "world",
+      labels: ["production"],
+    });
+
+    const exported = await makeAPICall<unknown[]>("GET", `${baseURI}/export`);
+    expect(exported.status).toBe(200);
+    const prompts = PromptSchema.array().parse(exported.body);
+    expect(prompts.length).toBe(2);
+
+    await pruneDatabase();
+
+    const importRes = await makeAPICall("POST", `${baseURI}/import`, {
+      prompts,
+    });
+    expect(importRes.status).toBe(201);
+
+    const { body } = await makeAPICall(
+      "GET",
+      `${baseURI}/${encodeURIComponent(prompts[0].name)}`,
+    );
+    expect(body.name).toBe(prompts[0].name);
+  });
+});

--- a/web/src/features/prompts/server/handlers/promptExportHandler.ts
+++ b/web/src/features/prompts/server/handlers/promptExportHandler.ts
@@ -1,0 +1,30 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+
+import { authorizePromptRequestOrThrow } from "../utils/authorizePromptRequest";
+import { withMiddlewares } from "@/src/features/public-api/server/withMiddlewares";
+import { prisma } from "@langfuse/shared/src/db";
+import { RateLimitService } from "@/src/features/public-api/server/RateLimitService";
+
+const getExportHandler = async (req: NextApiRequest, res: NextApiResponse) => {
+  const authCheck = await authorizePromptRequestOrThrow(req);
+
+  const rateLimitCheck = await RateLimitService.getInstance().rateLimitRequest(
+    authCheck.scope,
+    "prompts",
+  );
+
+  if (rateLimitCheck?.isRateLimited()) {
+    return rateLimitCheck.sendRestResponseIfLimited(res);
+  }
+
+  const prompts = await prisma.prompt.findMany({
+    where: { projectId: authCheck.scope.projectId },
+    orderBy: [{ name: "asc" }, { version: "asc" }],
+  });
+
+  return res.status(200).json(prompts);
+};
+
+export const promptExportHandler = withMiddlewares({
+  GET: getExportHandler,
+});

--- a/web/src/features/prompts/server/handlers/promptImportHandler.ts
+++ b/web/src/features/prompts/server/handlers/promptImportHandler.ts
@@ -1,0 +1,42 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import { z } from "zod";
+
+import { authorizePromptRequestOrThrow } from "../utils/authorizePromptRequest";
+import { withMiddlewares } from "@/src/features/public-api/server/withMiddlewares";
+import { createPrompt } from "@/src/features/prompts/server/actions/createPrompt";
+import { CreatePromptSchema } from "@/src/features/prompts/server/utils/validation";
+import { prisma } from "@langfuse/shared/src/db";
+import { RateLimitService } from "@/src/features/public-api/server/RateLimitService";
+
+const postImportHandler = async (req: NextApiRequest, res: NextApiResponse) => {
+  const authCheck = await authorizePromptRequestOrThrow(req);
+
+  const rateLimitCheck = await RateLimitService.getInstance().rateLimitRequest(
+    authCheck.scope,
+    "prompts",
+  );
+
+  if (rateLimitCheck?.isRateLimited()) {
+    return rateLimitCheck.sendRestResponseIfLimited(res);
+  }
+
+  const data = z
+    .object({ prompts: z.array(CreatePromptSchema) })
+    .parse(req.body);
+
+  for (const prompt of data.prompts) {
+    await createPrompt({
+      ...prompt,
+      config: prompt.config ?? {},
+      projectId: authCheck.scope.projectId,
+      createdBy: "API",
+      prisma,
+    });
+  }
+
+  return res.status(201).json({ success: true, count: data.prompts.length });
+};
+
+export const promptImportHandler = withMiddlewares({
+  POST: postImportHandler,
+});

--- a/web/src/pages/api/public/v2/prompts/export.ts
+++ b/web/src/pages/api/public/v2/prompts/export.ts
@@ -1,0 +1,1 @@
+export { promptExportHandler as default } from "@/src/features/prompts/server/handlers/promptExportHandler";

--- a/web/src/pages/api/public/v2/prompts/import.ts
+++ b/web/src/pages/api/public/v2/prompts/import.ts
@@ -1,0 +1,1 @@
+export { promptImportHandler as default } from "@/src/features/prompts/server/handlers/promptImportHandler";


### PR DESCRIPTION
## Summary
- add API route and handler to export prompts
- add API route and handler to import prompts
- test prompt export and import

## Testing
- `pnpm test` *(fails: connect EHOSTUNREACH when fetching pnpm)*