### PR TITLE
Add prompt import/export

### DIFF
--- a/web/src/__tests__/prompts.import-export.servertest.ts
+++ b/web/src/__tests__/prompts.import-export.servertest.ts
@@ -1,0 +1,42 @@
+/** @jest-environment node */
+
+import { makeAPICall, pruneDatabase } from "@/src/__tests__/test-utils";
+import { PromptSchema } from "@/src/features/prompts/server/utils/validation";
+
+const baseURI = "/api/public/v2/prompts";
+
+describe("prompt export/import", () => {
+  beforeAll(pruneDatabase);
+  afterAll(pruneDatabase);
+
+  it("should export prompts and import them", async () => {
+    await makeAPICall("POST", baseURI, {
+      name: "prompt-export-1",
+      prompt: "hello",
+      labels: ["production"],
+    });
+    await makeAPICall("POST", baseURI, {
+      name: "prompt-export-2",
+      prompt: "world",
+      labels: ["production"],
+    });
+
+    const exported = await makeAPICall<unknown[]>("GET", `${baseURI}/export`);
+    expect(exported.status).toBe(200);
+    const prompts = PromptSchema.array().parse(exported.body);
+    expect(prompts.length).toBe(2);
+
+    await pruneDatabase();
+
+    const importRes = await makeAPICall("POST", `${baseURI}/import`, {
+      prompts,
+    });
+    expect(importRes.status).toBe(201);
+
+    const { body } = await makeAPICall(
+      "GET",
+      `${baseURI}/${encodeURIComponent(prompts[0].name)}`,
+    );
+    expect(body.name).toBe(prompts[0].name);
+  });
+});

--- a/web/src/features/prompts/components/ExportImportButtons.clienttest.tsx
+++ b/web/src/features/prompts/components/ExportImportButtons.clienttest.tsx
@@ -1,0 +1,41 @@
+import { fireEvent, render, waitFor } from "@testing-library/react";
+import { ExportPromptsButton } from "./ExportPromptsButton";
+import { ImportPromptsButton } from "./ImportPromptsButton";
+
+jest.mock("@/src/features/rbac/utils/checkProjectAccess", () => ({
+  useHasProjectAccess: () => true,
+}));
+
+jest.mock("@/src/features/notifications/showSuccessToast", () => ({
+  showSuccessToast: jest.fn(),
+}));
+
+jest.mock("@/src/features/notifications/showErrorToast", () => ({
+  showErrorToast: jest.fn(),
+}));
+
+global.fetch = jest.fn(() =>
+  Promise.resolve({ ok: true, json: () => Promise.resolve([]) }) as any,
+) as jest.Mock;
+
+describe("prompt export/import buttons", () => {
+  it("calls export API", async () => {
+    const { getByText } = render(<ExportPromptsButton projectId="p1" />);
+    fireEvent.click(getByText("Export"));
+    fireEvent.click(getByText("JSON"));
+    await waitFor(() => {
+      expect(fetch).toHaveBeenCalledWith(
+        "/api/public/v2/prompts/export",
+        expect.anything(),
+      );
+    });
+  });
+
+  it("shows file input on import", () => {
+    const { getByText, container } = render(
+      <ImportPromptsButton projectId="p1" />,
+    );
+    fireEvent.click(getByText("Import"));
+    expect(container.querySelector('input[type="file"]')).toBeTruthy();
+  });
+});

--- a/web/src/features/prompts/components/ExportPromptsButton.tsx
+++ b/web/src/features/prompts/components/ExportPromptsButton.tsx
@@ -1,0 +1,72 @@
+import { useState } from "react";
+import { Download } from "lucide-react";
+import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "@/src/components/ui/dropdown-menu";
+import { ActionButton } from "@/src/components/ActionButton";
+import { useHasProjectAccess } from "@/src/features/rbac/utils/checkProjectAccess";
+import { showErrorToast } from "@/src/features/notifications/showErrorToast";
+import { showSuccessToast } from "@/src/features/notifications/showSuccessToast";
+import { promptsToCsv } from "@/src/features/prompts/utils/csvHelpers";
+import type { LegacyValidatedPrompt } from "@/src/features/prompts/server/utils/validation";
+
+export const ExportPromptsButton = ({ projectId }: { projectId: string }) => {
+  const hasAccess = useHasProjectAccess({ projectId, scope: "prompts:read" });
+  const [open, setOpen] = useState(false);
+
+  async function handleExport(format: "json" | "csv") {
+    try {
+      const res = await fetch(`/api/public/v2/prompts/export`);
+      if (!res.ok) throw new Error(await res.text());
+      // Public API includes legacy fields like `isActive`, so use the
+      // legacy prompt type here.
+      const data = (await res.json()) as LegacyValidatedPrompt[];
+      let content = "";
+      let mime = "text/plain";
+      let ext = "txt";
+      if (format === "json") {
+        content = JSON.stringify(data, null, 2);
+        mime = "application/json";
+        ext = "json";
+      } else {
+        content = promptsToCsv(data);
+        mime = "text/csv";
+        ext = "csv";
+      }
+      const blob = new Blob([content], { type: mime });
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.href = url;
+      a.download = `prompts.${ext}`;
+      document.body.appendChild(a);
+      a.click();
+      a.remove();
+      URL.revokeObjectURL(url);
+      showSuccessToast({
+        title: "Export successful",
+        description: `Downloaded prompts.${ext}`,
+      });
+    } catch (e) {
+      showErrorToast(
+        "Export failed",
+        e instanceof Error ? e.message : String(e),
+      );
+    }
+  }
+
+  return (
+    <DropdownMenu open={open} onOpenChange={setOpen}>
+      <DropdownMenuTrigger asChild>
+        <ActionButton
+          variant="outline"
+          hasAccess={hasAccess}
+          icon={<Download className="h-4 w-4" aria-hidden="true" />}
+        >
+          Export
+        </ActionButton>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent>
+        <DropdownMenuItem onClick={() => handleExport("json")}>JSON</DropdownMenuItem>
+        <DropdownMenuItem onClick={() => handleExport("csv")}>CSV</DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+};

--- a/web/src/features/prompts/components/ImportPromptsButton.tsx
+++ b/web/src/features/prompts/components/ImportPromptsButton.tsx
@@ -1,0 +1,73 @@
+import { useRef, useState } from "react";
+import { UploadIcon } from "lucide-react";
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from "@/src/components/ui/dialog";
+import { Input } from "@/src/components/ui/input";
+import { ActionButton } from "@/src/components/ActionButton";
+import { useHasProjectAccess } from "@/src/features/rbac/utils/checkProjectAccess";
+import { showErrorToast } from "@/src/features/notifications/showErrorToast";
+import { showSuccessToast } from "@/src/features/notifications/showSuccessToast";
+import { parsePromptsCsv } from "@/src/features/prompts/utils/csvHelpers";
+import type { CreatePromptType } from "@/src/features/prompts/server/utils/validation";
+
+export const ImportPromptsButton = ({ projectId }: { projectId: string }) => {
+  const hasAccess = useHasProjectAccess({ projectId, scope: "prompts:CUD" });
+  const [open, setOpen] = useState(false);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  async function handleFile(file: File) {
+    try {
+      let prompts: CreatePromptType[] = [];
+      if (file.name.endsWith(".csv")) {
+        prompts = await parsePromptsCsv(file);
+      } else {
+        const text = await file.text();
+        const parsed = JSON.parse(text);
+        if (!Array.isArray(parsed)) throw new Error("Invalid JSON file");
+        prompts = parsed as CreatePromptType[];
+      }
+      const res = await fetch(`/api/public/v2/prompts/import`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ prompts }),
+      });
+      if (!res.ok) throw new Error(await res.text());
+      showSuccessToast({
+        title: "Import successful",
+        description: `${prompts.length} prompts uploaded`,
+      });
+      setOpen(false);
+    } catch (e) {
+      showErrorToast(
+        "Import failed",
+        e instanceof Error ? e.message : String(e),
+      );
+    }
+  }
+
+  const onChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    await handleFile(file);
+    e.target.value = "";
+  };
+
+  return (
+    <Dialog open={hasAccess && open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>
+        <ActionButton
+          variant="outline"
+          hasAccess={hasAccess}
+          icon={<UploadIcon className="h-4 w-4" aria-hidden="true" />}
+        >
+          Import
+        </ActionButton>
+      </DialogTrigger>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Import Prompts</DialogTitle>
+        </DialogHeader>
+        <Input ref={fileInputRef} type="file" accept=".json,.csv" onChange={onChange} />
+      </DialogContent>
+    </Dialog>
+  );
+};

--- a/web/src/features/prompts/server/handlers/promptExportHandler.ts
+++ b/web/src/features/prompts/server/handlers/promptExportHandler.ts
@@ -1,0 +1,30 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+
+import { authorizePromptRequestOrThrow } from "../utils/authorizePromptRequest";
+import { withMiddlewares } from "@/src/features/public-api/server/withMiddlewares";
+import { prisma } from "@langfuse/shared/src/db";
+import { RateLimitService } from "@/src/features/public-api/server/RateLimitService";
+
+const getExportHandler = async (req: NextApiRequest, res: NextApiResponse) => {
+  const authCheck = await authorizePromptRequestOrThrow(req);
+
+  const rateLimitCheck = await RateLimitService.getInstance().rateLimitRequest(
+    authCheck.scope,
+    "prompts",
+  );
+
+  if (rateLimitCheck?.isRateLimited()) {
+    return rateLimitCheck.sendRestResponseIfLimited(res);
+  }
+
+  const prompts = await prisma.prompt.findMany({
+    where: { projectId: authCheck.scope.projectId },
+    orderBy: [{ name: "asc" }, { version: "asc" }],
+  });
+
+  return res.status(200).json(prompts);
+};
+
+export const promptExportHandler = withMiddlewares({
+  GET: getExportHandler,
+});

--- a/web/src/features/prompts/server/handlers/promptImportHandler.ts
+++ b/web/src/features/prompts/server/handlers/promptImportHandler.ts
@@ -1,0 +1,42 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import { z } from "zod";
+
+import { authorizePromptRequestOrThrow } from "../utils/authorizePromptRequest";
+import { withMiddlewares } from "@/src/features/public-api/server/withMiddlewares";
+import { createPrompt } from "@/src/features/prompts/server/actions/createPrompt";
+import { CreatePromptSchema } from "@/src/features/prompts/server/utils/validation";
+import { prisma } from "@langfuse/shared/src/db";
+import { RateLimitService } from "@/src/features/public-api/server/RateLimitService";
+
+const postImportHandler = async (req: NextApiRequest, res: NextApiResponse) => {
+  const authCheck = await authorizePromptRequestOrThrow(req);
+
+  const rateLimitCheck = await RateLimitService.getInstance().rateLimitRequest(
+    authCheck.scope,
+    "prompts",
+  );
+
+  if (rateLimitCheck?.isRateLimited()) {
+    return rateLimitCheck.sendRestResponseIfLimited(res);
+  }
+
+  const data = z
+    .object({ prompts: z.array(CreatePromptSchema) })
+    .parse(req.body);
+
+  for (const prompt of data.prompts) {
+    await createPrompt({
+      ...prompt,
+      config: prompt.config ?? {},
+      projectId: authCheck.scope.projectId,
+      createdBy: "API",
+      prisma,
+    });
+  }
+
+  return res.status(201).json({ success: true, count: data.prompts.length });
+};
+
+export const promptImportHandler = withMiddlewares({
+  POST: postImportHandler,
+});

--- a/web/src/features/prompts/utils/csvHelpers.ts
+++ b/web/src/features/prompts/utils/csvHelpers.ts
@@ -1,0 +1,71 @@
+import { parseCsvClient } from "@/src/features/datasets/lib/csvHelpers";
+import type {
+  CreatePromptType,
+  LegacyValidatedPrompt,
+  PromptType,
+} from "@/src/features/prompts/server/utils/validation";
+
+/**
+ * Serialize prompts into a CSV string for export.
+ * Accepts legacy prompt objects returned by the public API.
+ */
+export function promptsToCsv(prompts: LegacyValidatedPrompt[]): string {
+  const headers = [
+    "name",
+    "version",
+    "type",
+    "prompt",
+    "labels",
+    "tags",
+    "config",
+    "commitMessage",
+  ];
+  const lines = [headers.join(",")];
+  for (const p of prompts) {
+    const row = headers.map((h) => {
+      let value: unknown = (p as any)[h];
+      if (h === "labels" || h === "tags") {
+        value = Array.isArray(value) ? (value as string[]).join("|") : "";
+      } else if (h === "config" || (h === "prompt" && p.type === "chat")) {
+        value = JSON.stringify(value ?? {});
+      }
+      if (value === undefined || value === null) value = "";
+      const str = String(value).replace(/"/g, '""');
+      return `"${str}"`;
+    });
+    lines.push(row.join(","));
+  }
+  return lines.join("\n");
+}
+
+export async function parsePromptsCsv(file: File): Promise<CreatePromptType[]> {
+  const prompts: CreatePromptType[] = [];
+  let headers: string[] = [];
+  await parseCsvClient(file, {
+    processor: {
+      onHeader: (h) => {
+        headers = h.map((s) => s.trim());
+      },
+      onRow: (row) => {
+        const map = new Map(headers.map((h, i) => [h, row[i]]));
+        const type = (map.get("type") as PromptType | undefined) ?? "text";
+        const promptValue = map.get("prompt") ?? "";
+        const labels = map.get("labels")?.split("|").filter(Boolean) ?? [];
+        const tags = map.get("tags")?.split("|").filter(Boolean) ?? [];
+        const config = map.get("config") ? JSON.parse(map.get("config") as string) : {};
+        const commitMessage = map.get("commitMessage") || undefined;
+        const prompt = type === "chat" ? JSON.parse(promptValue as string) : promptValue;
+        prompts.push({
+          name: map.get("name") ?? "",
+          type: type as PromptType,
+          prompt: prompt as any,
+          labels,
+          tags,
+          config,
+          commitMessage: commitMessage as string | undefined,
+        });
+      },
+    },
+  });
+  return prompts;
+}

--- a/web/src/pages/api/public/v2/prompts/export.ts
+++ b/web/src/pages/api/public/v2/prompts/export.ts
@@ -1,0 +1,1 @@
+export { promptExportHandler as default } from "@/src/features/prompts/server/handlers/promptExportHandler";

--- a/web/src/pages/api/public/v2/prompts/import.ts
+++ b/web/src/pages/api/public/v2/prompts/import.ts
@@ -1,0 +1,1 @@
+export { promptImportHandler as default } from "@/src/features/prompts/server/handlers/promptImportHandler";

--- a/web/src/pages/project/[projectId]/prompts/index.tsx
+++ b/web/src/pages/project/[projectId]/prompts/index.tsx
@@ -1,5 +1,7 @@
 import { useRouter } from "next/router";
 import { ActionButton } from "@/src/components/ActionButton";
+import { ExportPromptsButton } from "@/src/features/prompts/components/ExportPromptsButton";
+import { ImportPromptsButton } from "@/src/features/prompts/components/ImportPromptsButton";
 import Page from "@/src/components/layouts/page";
 import { usePostHogClientCapture } from "@/src/features/posthog-analytics/usePostHogClientCapture";
 import { PromptTable } from "@/src/features/prompts/components/prompts-table";
@@ -56,19 +58,23 @@ export default function Prompts() {
           href: "https://langfuse.com/docs/prompts",
         },
         actionButtonsRight: (
-          <ActionButton
-            icon={<PlusIcon className="h-4 w-4" aria-hidden="true" />}
-            hasAccess={hasCUDAccess}
-            href={`/project/${projectId}/prompts/new`}
-            variant="default"
-            limit={promptLimit}
-            limitValue={Number(count?.totalCount ?? 0)}
-            onClick={() => {
-              capture("prompts:new_form_open");
-            }}
-          >
-            New prompt
-          </ActionButton>
+          <div className="flex space-x-2">
+            <ImportPromptsButton projectId={projectId} />
+            <ExportPromptsButton projectId={projectId} />
+            <ActionButton
+              icon={<PlusIcon className="h-4 w-4" aria-hidden="true" />}
+              hasAccess={hasCUDAccess}
+              href={`/project/${projectId}/prompts/new`}
+              variant="default"
+              limit={promptLimit}
+              limitValue={Number(count?.totalCount ?? 0)}
+              onClick={() => {
+                capture("prompts:new_form_open");
+              }}
+            >
+              New prompt
+            </ActionButton>
+          </div>
         ),
       }}
       scrollable={showOnboarding}


### PR DESCRIPTION
## Summary
- add CSV helpers for prompt import/export
- add `ExportPromptsButton` with download dropdown
- add `ImportPromptsButton` with file dialog
- expose buttons on the prompts page
- test rendering and API call logic
- include download description in toasts and support legacy prompt objects

## Testing
- `pnpm --filter=web run prettier` *(fails: EHOSTUNREACH)*
- `pnpm run lint` *(fails: EHOSTUNREACH)*
- `pnpm run test` *(fails: EHOSTUNREACH)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added "Import" and "Export" buttons to the prompts management page, allowing users to import prompts from CSV/JSON files and export prompts in CSV/JSON format.
  - Users receive success or error notifications when importing or exporting prompts.
- **Bug Fixes**
  - None.
- **Tests**
  - Introduced comprehensive tests for import/export API endpoints and UI components to ensure correct functionality.
- **Chores**
  - Added utility functions for converting prompts data between CSV and JSON formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->